### PR TITLE
Create Report_Issue

### DIFF
--- a/Report_Issue
+++ b/Report_Issue
@@ -1,0 +1,1 @@
+Drawio plugin has conflict with CKG-Edit and its media tools


### PR DESCRIPTION
Drawio plugin has conflict with CKG-Edit and its media tools
Problem: when I want to add a picture by media tool it shows the media empty and I can't add any picture